### PR TITLE
Fix build on macOS, update binaryninja-api.

### DIFF
--- a/plugin/gen_insn_text_funcs.py
+++ b/plugin/gen_insn_text_funcs.py
@@ -605,7 +605,7 @@ def gen_insn_text_func(tag, regs, imms):
 def process_all_tags(tagregs, tagimms):
   tag_to_fbody = OrderedDict({tag: '' for tag in tags})
   print('Processing %d tags in parallel' % (len(tags)))
-  with concurrent.futures.ProcessPoolExecutor(max_workers=5) as executor:
+  with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
     future_to_tag = {}
     for i, tag in enumerate(tags):
       if not behdict[tag]:

--- a/third_party/qemu-hexagon/opcodes.h
+++ b/third_party/qemu-hexagon/opcodes.h
@@ -20,6 +20,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "third_party/qemu-hexagon/attribs.h"
 #include "third_party/qemu-hexagon/bitmap.h"


### PR DESCRIPTION
Fixes build on macOS and also updates binaryninja-api to the latest stable version.

On macOS using ProcessPoolExecutor for some reason caused behdict to be empty. This changes ProcessPoolExecutor to  ThreadPoolExecutor. Using it doesn't make much sense since there is GIL, but at least it works fine.