### PR TITLE
Update arch_hexagon.cc

### DIFF
--- a/plugin/arch_hexagon.cc
+++ b/plugin/arch_hexagon.cc
@@ -350,6 +350,11 @@ private:
 
 extern "C" {
 BN_DECLARE_CORE_ABI_VERSION
+  
+BINARYNINJAPLUGIN void CorePluginDependencies() {
+  AddOptionalPluginDependency("view_elf");
+}
+  
 BINARYNINJAPLUGIN bool CorePluginInit() {
   Architecture *hexagon = new HexagonArchitecture("hexagon");
   Architecture::Register(hexagon);


### PR DESCRIPTION
This change fixes a  bug, in some cases the arch plugin is getting loaded before the view_elf module. This will lead to a unknown elf arch 164 error as the module will register before the view. This bug was encountered with binja 3.3+ on linux, where user specific modules are loaded before the core ones if no dependency is specified.